### PR TITLE
safer bash scripts with 'set -euxo pipefail'

### DIFF
--- a/script/environment_setup.sh
+++ b/script/environment_setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -x
+set -euxo pipefail
 
 if [[ -n "$1" && -n "$2" ]]; then
 	HOST_NAME=$1

--- a/script/environment_setup_binary.sh
+++ b/script/environment_setup_binary.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -x
+set -euxo pipefail
 
 if [[ -n "$1" && -n "$2" ]]; then
 	HOST_NAME=$1


### PR DESCRIPTION
exit immediately when a command fails.