### PR TITLE
#112 Add IP camera as input device.

### DIFF
--- a/dynamic_vino_lib/CMakeLists.txt
+++ b/dynamic_vino_lib/CMakeLists.txt
@@ -202,6 +202,7 @@ add_library(${PROJECT_NAME} SHARED
         src/inputs/realsense_camera.cpp
         src/inputs/realsense_camera_topic.cpp
         src/inputs/standard_camera.cpp
+        src/inputs/ip_camera.cpp
         src/inputs/video_input.cpp
         src/inputs/image_input.cpp
         src/models/base_model.cpp

--- a/dynamic_vino_lib/include/dynamic_vino_lib/inputs/ip_camera.hpp
+++ b/dynamic_vino_lib/include/dynamic_vino_lib/inputs/ip_camera.hpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @brief A header file with declaration for IpCamera class
+ * @file ip_camera.hpp
+ */
+
+#ifndef DYNAMIC_VINO_LIB__INPUTS__IP_CAMERA_HPP_
+#define DYNAMIC_VINO_LIB__INPUTS__IP_CAMERA_HPP_
+
+#include <opencv2/opencv.hpp>
+#include <opencv2/imgproc.hpp>
+#include "dynamic_vino_lib/inputs/base_input.hpp"
+
+namespace Input
+{
+/**
+ * @class IpCamera
+ * @brief Class for recieving a ip camera as input.
+ */
+class IpCamera : public BaseInputDevice
+{
+public:
+  explicit IpCamera(const std::string & ip_uri) : ip_uri_(ip_uri) {}
+  /**
+   * @brief Initialize the input device,
+   * for cameras, it will turn the camera on and get ready to read frames,
+   * for videos, it will open a video file.
+   * @return Whether the input device is successfully turned on.
+   */
+  bool initialize() override;
+  /**
+   * @brief
+   * Initialize camera by uri of IP camera.
+   * @return Whether the input device is successfully turned on.
+   */
+  bool initialize(int t) override
+  {
+    return initialize();
+  }
+  /**
+   * @brief Initialize the input device with given width and height.
+   * @return Whether the input device is successfully turned on.
+   */
+  bool initialize(size_t width, size_t height) override;
+  /**
+   * @brief Read next frame, and give the value to argument frame.
+   * @return Whether the next frame is successfully read.
+   */
+  bool read(cv::Mat * frame) override;
+
+private:
+  cv::VideoCapture cap;
+  std::string ip_uri_;
+};
+}  // namespace Input
+#endif  // DYNAMIC_VINO_LIB__INPUTS__IP_CAMERA_HPP_

--- a/dynamic_vino_lib/include/dynamic_vino_lib/pipeline_params.hpp
+++ b/dynamic_vino_lib/include/dynamic_vino_lib/pipeline_params.hpp
@@ -36,6 +36,7 @@
 const char kInputType_Image[] = "Image";
 const char kInputType_Video[] = "Video";
 const char kInputType_StandardCamera[] = "StandardCamera";
+const char kInputType_IpCamera[] = "IpCamera";
 const char kInputType_CameraTopic[] = "RealSenseCameraTopic";
 const char kInputType_RealSenseCamera[] = "RealSenseCamera";
 const char kInputType_ServiceImage[] = "ServiceImage";

--- a/dynamic_vino_lib/src/factory.cpp
+++ b/dynamic_vino_lib/src/factory.cpp
@@ -23,6 +23,7 @@
 #include "dynamic_vino_lib/factory.hpp"
 #include "dynamic_vino_lib/inputs/realsense_camera.hpp"
 #include "dynamic_vino_lib/inputs/standard_camera.hpp"
+#include "dynamic_vino_lib/inputs/ip_camera.hpp"
 #include "dynamic_vino_lib/inputs/video_input.hpp"
 #include "dynamic_vino_lib/inputs/realsense_camera_topic.hpp"
 #include "dynamic_vino_lib/inputs/image_input.hpp"
@@ -36,6 +37,8 @@ std::shared_ptr<Input::BaseInputDevice> Factory::makeInputDeviceByName(
     return std::make_unique<Input::RealSenseCamera>();
   } else if (input_device_name == "StandardCamera") {
     return std::make_unique<Input::StandardCamera>();
+  } else if (input_device_name == "Video") {
+    return std::make_unique<Input::IpCamera>(input_file_path);
   } else if (input_device_name == "RealSenseCameraTopic") {
     std::cout << "tring to create instance for " << input_device_name << std::endl;
     return std::make_unique<Input::RealSenseCameraTopic>();

--- a/dynamic_vino_lib/src/inputs/ip_camera.cpp
+++ b/dynamic_vino_lib/src/inputs/ip_camera.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @brief a header file with declaration of IpCamera class
+ * @file ip_camera.cpp
+ */
+#include "dynamic_vino_lib/inputs/ip_camera.hpp"
+
+
+bool Input::IpCamera::initialize()
+{
+  setInitStatus(cap.open(ip_uri_));
+  // Initialize width and height to reasonable dimensions
+  setWidth(640);
+  setHeight(480);
+  return isInit();
+}
+
+bool Input::IpCamera::initialize(size_t width, size_t height)
+{
+  setInitStatus(cap.open(ip_uri_));
+  if (isInit()) {
+    setWidth(width);
+    setHeight(height);
+  }
+  return isInit();
+}
+
+bool Input::IpCamera::read(cv::Mat * frame)
+{
+  if (!isInit()) {
+    return false;
+  }
+  cap.grab();
+  setHeader("ip_camera_frame");
+  bool retrieved = cap.retrieve(*frame);
+  if (retrieved) {
+    cv::resize(*frame, *frame, cv::Size(getWidth(), getHeight()), 0, 0, CV_INTER_AREA);
+  }
+  return retrieved;
+}

--- a/dynamic_vino_lib/src/pipeline_manager.cpp
+++ b/dynamic_vino_lib/src/pipeline_manager.cpp
@@ -40,6 +40,7 @@
 #include "dynamic_vino_lib/inputs/realsense_camera.hpp"
 #include "dynamic_vino_lib/inputs/realsense_camera_topic.hpp"
 #include "dynamic_vino_lib/inputs/standard_camera.hpp"
+#include "dynamic_vino_lib/inputs/ip_camera.hpp"
 #include "dynamic_vino_lib/inputs/video_input.hpp"
 #include "dynamic_vino_lib/models/age_gender_detection_model.hpp"
 #include "dynamic_vino_lib/models/emotion_detection_model.hpp"
@@ -126,6 +127,10 @@ PipelineManager::parseInputDevice(const Params::ParamManager::PipelineRawData & 
       device = std::make_shared<Input::RealSenseCamera>();
     } else if (name == kInputType_StandardCamera) {
       device = std::make_shared<Input::StandardCamera>();
+    } else if (name == kInputType_IpCamera) {
+      if (params.input_meta != "") {
+        device = std::make_shared<Input::IpCamera>(params.input_meta);
+      }
     } else if (name == kInputType_CameraTopic) {
       device = std::make_shared<Input::RealSenseCameraTopic>();
     } else if (name == kInputType_Video) {

--- a/sample/launch/pipeline_people_ip.launch.py
+++ b/sample/launch/pipeline_people_ip.launch.py
@@ -1,0 +1,50 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Launch face detection and rviz."""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+import launch_ros.actions
+
+
+def generate_launch_description():
+    default_yaml = os.path.join(get_package_share_directory('dynamic_vino_sample'), 'param',
+                                'pipeline_people_ip.yaml')
+    default_rviz = os.path.join(get_package_share_directory('dynamic_vino_sample'), 'launch',
+                                'rviz/default.rviz')
+    return LaunchDescription([
+        # Openvino detection
+        launch_ros.actions.Node(
+            package='dynamic_vino_sample', node_executable='pipeline_with_params',
+            arguments=['-config', default_yaml],
+            remappings=[
+                ('/openvino_toolkit/people/detected_objects',
+                 '/ros2_openvino_toolkit/face_detection'),
+                ('/openvino_toolkit/people/emotions',
+                 '/ros2_openvino_toolkit/emotions_recognition'),
+                ('/openvino_toolkit/people/headposes',
+                 '/ros2_openvino_toolkit/headposes_estimation'),
+                ('/openvino_toolkit/people/age_genders',
+                 '/ros2_openvino_toolkit/age_genders_Recognition'),
+                ('/openvino_toolkit/people/images', '/ros2_openvino_toolkit/image_rviz')],
+            output='screen'),
+
+        # Rviz
+        launch_ros.actions.Node(
+            package='rviz2', node_executable='rviz2', output='screen',
+            arguments=['--display-config', default_rviz]),
+    ])

--- a/sample/param/pipeline_people_ip.yaml
+++ b/sample/param/pipeline_people_ip.yaml
@@ -1,0 +1,41 @@
+Pipelines:
+- name: people
+  inputs: [IpCamera]
+  input_path: "rtsp://"
+  infers:
+    - name: FaceDetection
+      model: /opt/openvino_toolkit/open_model_zoo/model_downloader/Transportation/object_detection/face/pruned_mobilenet_reduced_ssd_shared_weights/dldt/face-detection-adas-0001.xml
+      engine: CPU
+      label: to/be/set/xxx.labels
+      batch: 1
+      confidence_threshold: 0.5
+      enable_roi_constraint: true # set enable_roi_constraint to false if you don't want to make the inferred ROI (region of interest) constrained into the camera frame
+    - name: AgeGenderRecognition
+      model: /opt/openvino_toolkit/open_model_zoo/model_downloader/Retail/object_attributes/age_gender/dldt/age-gender-recognition-retail-0013.xml
+      engine: CPU
+      label: to/be/set/xxx.labels
+      batch: 16
+    - name: EmotionRecognition
+      model: /opt/openvino_toolkit/open_model_zoo/model_downloader/Retail/object_attributes/emotions_recognition/0003/dldt/emotions-recognition-retail-0003.xml
+      engine: CPU
+      label: to/be/set/xxx.labels
+      batch: 16
+    - name: HeadPoseEstimation
+      model: /opt/openvino_toolkit/open_model_zoo/model_downloader/Transportation/object_attributes/headpose/vanilla_cnn/dldt/head-pose-estimation-adas-0001.xml
+      engine: CPU
+      label: to/be/set/xxx.labels
+      batch: 16
+  outputs: [ImageWindow, RosTopic, RViz]
+  connects:
+    - left: IpCamera
+      right: [FaceDetection]
+    - left: FaceDetection
+      right: [AgeGenderRecognition, EmotionRecognition, HeadPoseEstimation, ImageWindow, RosTopic, RViz]
+    - left: AgeGenderRecognition
+      right: [ImageWindow, RosTopic, RViz]
+    - left: EmotionRecognition
+      right: [ImageWindow, RosTopic, RViz]
+    - left: HeadPoseEstimation
+      right: [ImageWindow, RosTopic, RViz]
+
+OpenvinoCommon:


### PR DESCRIPTION
1. I have added IpCamera as an input device to handle inputs from an IP camera.
- allows user to pass a rtsp address (e.g."rtsp://admin:admin@199.199.1.99:80/cam/realmonitor?channel=1&subtype=0") through the `input_path` parameter in the yaml file.
2. I have also included a sample launch file and configuration file.
3. Unlike the StandardCamera input device, images from an IP camera need to be manually resized. I have set default dimensions as (640x480).