### PR TITLE
Update doc with git branch of image_common

### DIFF
--- a/doc/OPEN_SOURCE_CODE_README.md
+++ b/doc/OPEN_SOURCE_CODE_README.md
@@ -145,7 +145,7 @@ This project is a ROS2 wrapper for CV API of [OpenVINO™](https://software.inte
 	git clone https://github.com/intel/ros2_object_msgs
 	git clone https://github.com/ros-perception/vision_opencv -b ros2
 	git clone https://github.com/ros2/message_filters.git
-	git clone https://github.com/ros-perception/image_common.git -b ros2
+	git clone https://github.com/ros-perception/image_common.git -b dashing
 	git clone https://github.com/intel/ros2_intel_realsense.git -b refactor
 	```
 


### PR DESCRIPTION
`git clone https://github.com/ros-perception/image_common.git -b ros2` in the step of  `Install ROS2_OpenVINO packages`  will result in the following error in `ROS-Dashing`:

`rcpputils error` by `ros2` branch
![rcpputils_error](https://user-images.githubusercontent.com/17681580/69345251-c9096b00-0cab-11ea-8335-5cd2ad0e34cd.png)



I compared the source code with two branches:
`ros2 `
![ros2](https://user-images.githubusercontent.com/17681580/69345193-b2631400-0cab-11ea-99e1-74da7bacf053.png)

`dashing`
![dashing](https://user-images.githubusercontent.com/17681580/69345155-a0817100-0cab-11ea-8439-8f1ed84f670d.png)

