### PR TITLE
add support to specify device node

### DIFF
--- a/openvino_param_lib/param/pipeline.yaml
+++ b/openvino_param_lib/param/pipeline.yaml
@@ -71,6 +71,7 @@ Pipelines:
 Common:
   camera_topic: /any/foloder/image_raw/
   input_path: /file
+  input_dev: /dev
   custom_cpu_library: okok
   enable_performance_count: true
 

--- a/openvino_param_lib/src/param_manager.cpp
+++ b/openvino_param_lib/src/param_manager.cpp
@@ -76,6 +76,7 @@ void operator>>(const YAML::Node & node, ParamManager::PipelineRawData & pipelin
   YAML_PARSE(node, "connects", pipeline.connects)
   YAML_PARSE(node, "connects", pipeline.filters)
   YAML_PARSE(node, "input_path", pipeline.input_meta)
+  YAML_PARSE(node, "input_dev", pipeline.input_meta)
   slog::info << "Pipeline Params:name=" << pipeline.name << slog::endl;
 }
 

--- a/openvino_wrapper_lib/include/openvino_wrapper_lib/inputs/standard_camera.hpp
+++ b/openvino_wrapper_lib/include/openvino_wrapper_lib/inputs/standard_camera.hpp
@@ -40,6 +40,7 @@ namespace Input
 class StandardCamera : public BaseInputDevice
 {
 public:
+  explicit StandardCamera(const std::string &);
   /**
    * @brief Initialize the input device,
    * for cameras, it will turn the camera on and get ready to read frames,

--- a/openvino_wrapper_lib/src/inputs/standard_camera.cpp
+++ b/openvino_wrapper_lib/src/inputs/standard_camera.cpp
@@ -18,6 +18,14 @@
  */
 #include "openvino_wrapper_lib/inputs/standard_camera.hpp"
 
+
+Input::StandardCamera::StandardCamera(const std::string & dev)
+{
+  if (!dev.empty() && isdigit(dev.back())) {
+      camera_id_ = dev.back() - '0';
+  }
+}
+
 bool Input::StandardCamera::initialize()
 {
   return initialize(640, 480);

--- a/openvino_wrapper_lib/src/pipeline_manager.cpp
+++ b/openvino_wrapper_lib/src/pipeline_manager.cpp
@@ -129,7 +129,7 @@ PipelineManager::parseInputDevice(const PipelineData & pdata)
     if (name == kInputType_RealSenseCamera) {
       device = std::make_shared<Input::RealSenseCamera>();
     } else if (name == kInputType_StandardCamera) {
-      device = std::make_shared<Input::StandardCamera>();
+      device = std::make_shared<Input::StandardCamera>(pdata.params.input_meta);
     } else if (name == kInputType_IpCamera) {
       if (pdata.params.input_meta != "") {
         device = std::make_shared<Input::IpCamera>(pdata.params.input_meta);


### PR DESCRIPTION
when input device is standard camera, it's optinal to add input_dev in yaml to specify device node